### PR TITLE
Add VPNSecurityGroup to sc-vpc-ra

### DIFF
--- a/vpc/sc-vpc-ra.yaml
+++ b/vpc/sc-vpc-ra.yaml
@@ -333,6 +333,23 @@ Resources:
       RuleAction: allow
       Egress: true
       CidrBlock: '0.0.0.0/0'
+  VPNSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security Group for VPN
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - CidrIp: !Ref VPCCIDR
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: '-1'
+          Description: 'Allow all VPN traffic'
+      # CF does not support removing all rules, workaround is to add a pointless rule
+      SecurityGroupEgress:
+        - CidrIp: '0.0.0.0/0'
+          FromPort: -1
+          ToPort: -1
+          IpProtocol: '-1'
   BastionSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: CreateBastionResources
@@ -480,3 +497,9 @@ Outputs:
   BastionSSHCIDR:
     Value: !Ref 'BastionSSHCIDR'
     Condition: CreateBastionResources
+  VPNSecurityGroupID:
+    Description: 'VPN Security Group Id'
+    Value: !Ref VPNSecurityGroup
+    Export:
+      Name:
+        !Join ['-', [!Ref 'AWS::Region', !Sub '${AWS::StackName}', 'VPNSecurityGroupID']]


### PR DESCRIPTION
Adds security group to the vpc product based on VPNSecurityGroup defined in aws-infra's [vpc.yaml](https://github.com/Sage-Bionetworks/aws-infra/blob/master/templates/vpc.yaml).

If preferred I could rename this to something like VPCCIDRSecurityGroup and change the description to something like ''Allow all traffic from same CIDR as the VPC".