### PR TITLE
clean deployed files

### DIFF
--- a/deploy-templates.sh
+++ b/deploy-templates.sh
@@ -7,7 +7,10 @@ S3_BUCKET=$(aws cloudformation list-exports --query "Exports[?Name=='us-east-1-b
 S3_BUCKET_PATH="$REPO_NAME/$TRAVIS_BRANCH"
 S3_BUCKET_URL="s3://$S3_BUCKET/$S3_BUCKET_PATH"
 
-# Upload local dirs to S3 bucket
+# Clean existing files on S3 bucket
+aws s3 rm --recursive $S3_BUCKET_URL/
+
+# Upload dirs and files to S3 bucket
 DIRS=$(ls -d */)
 for dir in $DIRS
 do


### PR DESCRIPTION
We typically make PR changes that add and delete files all the time.
If we don't clean up the repo we store them in then templates that
we delete thru PR will never get removed from the repo.  This
fixes that situation by removing existing templates and replacing
them with the latest files.